### PR TITLE
Changed three names. Beware: different tests must hve different names.

### DIFF
--- a/manual/rcu/LISAStern.2016.02.24a.litmus
+++ b/manual/rcu/LISAStern.2016.02.24a.litmus
@@ -1,4 +1,4 @@
-LISA LISA1Rib1G
+LISA  LISAStern.2016.02.24a
 (*
  * Result: Sometimes
  *

--- a/manual/rcu/LISAnoDL0.litmus
+++ b/manual/rcu/LISAnoDL0.litmus
@@ -1,4 +1,4 @@
-LISA LISADL1
+LISA LISAnoDL0
 (*
  * Result: Always
  *

--- a/manual/rcu/LISAnoDL1.litmus
+++ b/manual/rcu/LISAnoDL1.litmus
@@ -1,4 +1,4 @@
-LISA LISADL1
+LISA LISAnoDL1
 (*
  * Result: Always
  *


### PR DESCRIPTION
Dear Paul, would you please accept my pull request.
I have simply changed the names of three tests (the name is found after the
keyword LISA).
The reason is as follows: all diy tools use this name as a key to tests, and tests with the same name
must be the same.

--Luc
