### PR TITLE
1. Use correct LISA syntax for operation (mp+o-rel+deref-addr-o.litmus)

### DIFF
--- a/manual/extra/mp+o-rel+deref-addr-o.litmus
+++ b/manual/extra/mp+o-rel+deref-addr-o.litmus
@@ -3,9 +3,8 @@ LISA MP+o-rel+deref-addr-o
 a = 1;
 x = 2;
 }
- P0              | P1             ;
- w[once] a 3     | r[deref] r1 x  ;
-                 | xor r9, r1, r1 ;
-                 | add r3, a, r9  ;
- w[release] x 4  | r[once] r2 r3  ;
+ P0              | P1                  ;
+ w[once] a 3     | r[deref] r1 x       ;
+                 | mov r9 (and r1 128) ;
+ w[release] x 4  | r[once] r2 a+r9     ;
 exists (1:r1 = 4 /\ 1:r2 = 1)

--- a/manual/lwn573497/r+srcu+rl-rul.litmus
+++ b/manual/lwn573497/r+srcu+rl-rul.litmus
@@ -1,4 +1,4 @@
-LISA R+rl-rul+srcu (*14-RCU*)
+LISA R+srcu+rl-rul (*14-RCU*)
 (* Forbid: At least as many GPs and RCU RS CSes. *)
 {
 x = 0;

--- a/manual/lwn573497/s+o-wmb-o+rl-deref-addr-rul.litmus
+++ b/manual/lwn573497/s+o-wmb-o+rl-deref-addr-rul.litmus
@@ -1,4 +1,4 @@
-LISA s+o-assign+rl-deref-addr-rul (*7-light*)
+LISA s+o-wmb-o+rl-deref-addr-rul (*7-light*)
 (*
  * Forbid: Address dependency in P1 and wmb in P0, write-to-read
  * relationship.  (Note: Reworked to apply to ARM as well as PowerPC.)

--- a/manual/lwn573497/wrc+o+o-assign+rl-lderef-addr-rul.litmus
+++ b/manual/lwn573497/wrc+o+o-assign+rl-lderef-addr-rul.litmus
@@ -1,4 +1,4 @@
-LISA WRC+o+o-assign+rl-deref-addr-rul (*1-light*)
+LISA WRC+o+o-assign+rl-lderef-addr-rul (*1-light*)
 (*
  * Forbid: Address dependency in P2 and release in P0, write-to-read
  * relationship.  (Note: Reworked to apply to ARM as well as PowerPC.)


### PR DESCRIPTION
1. Change three incorrect test names.
