### PR TITLE
Change initialisation of two tests for the sake of typing real code.

### DIFF
--- a/manual/rcu/LISA1Rd1G.litmus
+++ b/manual/rcu/LISA1Rd1G.litmus
@@ -8,7 +8,7 @@ LISA LISA1Rd1G
  *)
 {
 x0 = x1;
-x1 = x2;
+x1 = 0;
 x2 = 42;
 0:r5=x2;
 }
@@ -17,4 +17,5 @@ x2 = 42;
  call[sync]      | r[deref] r1 x0 ;
  w[once] x1 7    | r[once] r2 r1  ;
                  | f[unlock]      ;
-exists (1:r1=1:r1 /\ 1:r2=7)
+locations [1:r1*;]
+exists (1:r2=7)

--- a/manual/rcu/LISA1Rdc1G-buggy.litmus
+++ b/manual/rcu/LISA1Rdc1G-buggy.litmus
@@ -1,4 +1,4 @@
-LISA LISA1Rdc1G
+LISA LISA1Rdc1G-buggy
 (*
  * Result: Never
  *
@@ -9,7 +9,7 @@ LISA LISA1Rdc1G
  *)
 {
 x0 = x1;
-x1 = x2;
+x1 = 0;
 x2 = 42;
 x3 = x5;
 x4 = 66;
@@ -23,4 +23,5 @@ x5 = 15;
  call[sync]    | r[once] r2 r1 |               ;
  w[once] x1 7  | w[once] x4 r2 |               ;
                | f[unlock]     |               ;
-exists (1:r1=1:r1 /\ 2:r1=2:r1 /\ (1:r2=7 \/ 2:r2=15))
+locations [1:r1*; 2:r1*;]
+exists (1:r2=7 \/ 2:r2=15)


### PR DESCRIPTION
Also removed 1:r1 = 1:r1  in favor of locations [1:r1*]. This is
a more straightforward way to observe a pointer.
